### PR TITLE
chore: update application versions

### DIFF
--- a/charts/aws-sigv4-proxy/Chart.yaml
+++ b/charts/aws-sigv4-proxy/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.9"
+appVersion: "v0.1.10"

--- a/charts/git-events-runner/Chart.yaml
+++ b/charts/git-events-runner/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.13
+version: 0.4.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.4.13"
+appVersion: "v0.4.14"

--- a/charts/psql-query-exporter/Chart.yaml
+++ b/charts/psql-query-exporter/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.5
+version: 0.5.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.3.5"
+appVersion: "v0.3.6"


### PR DESCRIPTION
## Summary

Updates application and chart versions for three Helm charts:

- **aws-sigv4-proxy**: v0.1.9 → v0.1.11
- **git-events-runner**: v0.4.13 → v0.4.14
- **psql-query-exporter**: v0.5.5 → v0.5.6 (appVersion v0.3.5 → v0.3.6)

Each chart's version and appVersion fields have been incremented to reflect the latest application releases.